### PR TITLE
Add fix for the Brew of Raising

### DIFF
--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
@@ -103,6 +103,10 @@ public class ModConfig {
             @Config.Name("Brew of Tidal Hold - Fix Entity Suffocation")
             public static boolean tidalHold_fixEntitySuffocation = true;
 
+            @Config.Comment("Fixes some dispersal methods of the brew of raising causing a crash")
+            @Config.Name("Brew of Raising - Fix NUll Player Name Crash")
+            public static boolean raising_fixNullPlayerName = true;
+
             @Config.Comment("If true, gives CraftTweaker integration total control about which blocks can be mined or destroyed, " +
                     "enabling a much more in-depth customizability. If set to True, but no script changes it, behaviour is default Witchery")
             @Config.Name("Brew of Erosion - Tweak Effect With Crafttweaker")

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/potion/PotionEnslavedMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/potion/PotionEnslavedMixin.java
@@ -1,0 +1,25 @@
+package com.smokeythebandicoot.witcherycompanion.mixins.potion;
+
+import com.smokeythebandicoot.witcherycompanion.config.ModConfig;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import net.msrandom.witchery.potion.PotionEnslaved;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PotionEnslaved.class)
+public class PotionEnslavedMixin {
+	@SuppressWarnings("ConstantValue")
+	@Inject(method = "setEnslaverForMob", remap = false, cancellable = true, at = @At("HEAD"))
+	private static void setEnslaverForMob(EntityLiving entity, EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+		if (!ModConfig.PatchesConfiguration.BrewsTweaks.raising_fixNullPlayerName) {
+			return;
+		}
+
+		if (player == null || player.getName() == null || player.getName().isEmpty()) {
+			cir.setReturnValue(false);
+		}
+	}
+}

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/potion/PotionEnslavedMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/potion/PotionEnslavedMixin.java
@@ -11,15 +11,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PotionEnslaved.class)
 public class PotionEnslavedMixin {
-	@SuppressWarnings("ConstantValue")
-	@Inject(method = "setEnslaverForMob", remap = false, cancellable = true, at = @At("HEAD"))
-	private static void setEnslaverForMob(EntityLiving entity, EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
-		if (!ModConfig.PatchesConfiguration.BrewsTweaks.raising_fixNullPlayerName) {
-			return;
-		}
+    @SuppressWarnings("ConstantValue")
+    @Inject(method = "setEnslaverForMob", remap = false, cancellable = true, at = @At("HEAD"))
+    private static void setEnslaverForMob(EntityLiving entity, EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+        if (!ModConfig.PatchesConfiguration.BrewsTweaks.raising_fixNullPlayerName) {
+            return;
+        }
 
-		if (player == null || player.getName() == null || player.getName().isEmpty()) {
-			cir.setReturnValue(false);
-		}
-	}
+        if (player == null || player.getName() == null || player.getName().isEmpty()) {
+            cir.setReturnValue(false);
+        }
+    }
 }

--- a/src/main/resources/mixins.witcherycompanion.json
+++ b/src/main/resources/mixins.witcherycompanion.json
@@ -37,6 +37,7 @@
     "item.ItemChalkMixin",
     "item.ItemSpectralStoneMixin",
     "item.brews.ItemErosionBrewMixin",
+    "potion.PotionEnslavedMixin",
     "potion.PotionFortuneMixin",
     "rite.effect.RiteEffectMovingEarthMixin",
     "util.EntityUtilMixin",


### PR DESCRIPTION
Seemingly the EntityPlayer::getName function returned null, thus this adds an extra check against that.

Relevant stacktrace:
```
at java.util.Objects.requireNonNull(Objects.java:228)
at net.minecraft.nbt.NBTTagString.<init>(NBTTagString.java:19)
at net.minecraft.nbt.NBTTagCompound.func_74778_a(NBTTagCompound.java:149)
at net.msrandom.witchery.potion.PotionEnslaved.setEnslaverForMob(PotionEnslaved.java:37)
at net.msrandom.witchery.brewing.action.effect.BrewActionRaising.raiseUndead(BrewActionRaising.java:64)
at net.msrandom.witchery.brewing.action.effect.BrewActionRaising.raiseDead(BrewActionRaising.java:29)
at net.msrandom.witchery.brewing.action.effect.BrewActionRaising.doApplyToBlock(BrewActionRaising.java:84)
at net.msrandom.witchery.brewing.action.effect.BrewActionEffect.applyToBlock(BrewActionEffect.java:52)
at net.msrandom.witchery.brewing.action.EffectBrewAction.applyToBlock(EffectBrewAction.kt:56)
at net.msrandom.witchery.brewing.action.BrewActionList.applyToBlock(BrewActionList.java:75)
at net.msrandom.witchery.block.BlockLiquidBrew.func_180650_b(BlockLiquidBrew.java:140)
```
