### PR TITLE
Remove unused EventBusSubscriber annotation

### DIFF
--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/patches/infusion/symbol/SymbolEffectPatch.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/patches/infusion/symbol/SymbolEffectPatch.java
@@ -10,7 +10,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 /**
  [Bugfix] Fixes persistency with NBT data being wiped on death. For example, infusions
  */
-@Mod.EventBusSubscriber(modid = WitcheryCompanion.MODID)
 public class SymbolEffectPatch {
 
     private static SymbolEffectPatch INSTANCE = null;
@@ -37,7 +36,5 @@ public class SymbolEffectPatch {
 
         NBTTagCompound acquiredKnowledge = oldPlayer.getEntityData().getCompoundTag("WitcherySpellBook");
         newPlayer.getEntityData().setTag("WitcherySpellBook", acquiredKnowledge);
-
     }
-
 }

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/patches/infusion/symbol/SymbolEffectPatch.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/patches/infusion/symbol/SymbolEffectPatch.java
@@ -36,5 +36,7 @@ public class SymbolEffectPatch {
 
         NBTTagCompound acquiredKnowledge = oldPlayer.getEntityData().getCompoundTag("WitcherySpellBook");
         newPlayer.getEntityData().setTag("WitcherySpellBook", acquiredKnowledge);
+
     }
+
 }


### PR DESCRIPTION
To reduce confusion, as the event handler is registered elsewhere manually rather than automatically with the annotation, thus leaving the annotation to do nothing.
