### PR TITLE
Add automatic download for the Witchery 1.7.10 Jar

### DIFF
--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/WitcheryCompanion.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/WitcheryCompanion.java
@@ -1,11 +1,14 @@
 package com.smokeythebandicoot.witcherycompanion;
 
 import com.smokeybandicoot.witcherycompanion.Tags;
+import com.smokeythebandicoot.witcherycompanion.client.WitcheryJarDownloader;
 import com.smokeythebandicoot.witcherycompanion.proxy.CommonProxy;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLConstructionEvent;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +33,7 @@ public class WitcheryCompanion implements ILateMixinLoader {
     public static final String MODCREDITS = "";
     public static final String MODURL = "";
     public static final String MODLOGO = "assets/witcherycompanion/logo.png";
-    public static final String MODDEPS = "required-after:witchery";
+    public static final String MODDEPS = "required-before:witchery";
     public static final String MODDESCRIPTION = "A Companion mod for Witchery Resurrected, patching bugs, adding " +
             "integrations and introducing modpack maker-oriented features";
 
@@ -42,6 +45,14 @@ public class WitcheryCompanion implements ILateMixinLoader {
     @SidedProxy(clientSide = "com.smokeythebandicoot.witcherycompanion.proxy.ClientProxy",
                 serverSide = "com.smokeythebandicoot.witcherycompanion.proxy.CommonProxy")
     public static CommonProxy proxy;
+
+    // This is an internal event that is not supposed to be used, but since it's 1.12 and this doesn't need to exist on higher versions; it doesn't matter.
+    @EventHandler
+    public void onConstruction(FMLConstructionEvent event) {
+        if (FMLCommonHandler.instance().getSide().isClient()) {
+            WitcheryJarDownloader.downloadJar();
+        }
+    }
 
     @EventHandler
     public void onPreInit(FMLPreInitializationEvent event) {

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/client/WitcheryJarDownloader.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/client/WitcheryJarDownloader.java
@@ -1,0 +1,58 @@
+package com.smokeythebandicoot.witcherycompanion.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.include.com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class WitcheryJarDownloader {
+    private static final String FILE_NAME = "witchery-1.7.10-0.24.1.jar";
+    private static final String WITCHERY_1_7_10_DOWNLOAD_URL = "https://mediafilez.forgecdn.net/files/2234/410/" + FILE_NAME;
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static boolean isValidFile(Path jarFile) throws IOException {
+        if (!Files.isRegularFile(jarFile)) {
+            return false;
+        }
+
+        try (InputStream existingFile = Files.newInputStream(jarFile)) {
+            return DigestUtils.md5Hex(existingFile).equals("22096b8e462fa5cca3a6c8054116d4fc");
+        }
+    }
+
+    private static void downloadJar(Path jarFile) throws IOException {
+        if (!isValidFile(jarFile)) {
+            Files.deleteIfExists(jarFile);
+        }
+
+        try (
+                InputStream download = new URL(WITCHERY_1_7_10_DOWNLOAD_URL).openStream();
+                OutputStream output = Files.newOutputStream(jarFile)
+        ) {
+            ByteStreams.copy(download, output);
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void downloadJar() {
+        Path resourcePacksDirectory = Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks().toPath();
+        Path jarFile = resourcePacksDirectory.resolve(FILE_NAME);
+
+        try {
+            downloadJar(jarFile);
+        } catch (IOException exception) {
+            LOGGER.warn("Failed to download original Witchery 1.7.10 Jar from {}, got exception {}", WITCHERY_1_7_10_DOWNLOAD_URL, exception);
+        }
+    }
+}


### PR DESCRIPTION
Allows Witchery: Resurrected in 1.12.2 to be used on its own with just this mod, without needing additional steps.

- Downloads before mod construction, to allow the logic to happen before resourcepack creation
- Client only, as it has no reason to exist on the server side
- Changes the loading order to force this to be before Witchery: Resurrected in loading
