### PR TITLE
Prevent replacing Circle Glyph

### DIFF
--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
@@ -421,6 +421,10 @@ public class ModConfig {
             @Config.Name("Circle Glyph - Fix Out Of Bounds Crash")
             public static boolean circleGlyph_fixOutOfBoundsCrash = true;
 
+            @Config.Comment("If true, prevents the Circle Glyph from being directly replaced by other blocks.")
+            @Config.Name("Circle Glyph - Prevent Being Replaced")
+            public static boolean circleGlyph_preventBeingReplaced = true;
+
             @Config.Comment("Fix an edge case where the coffin would not have a color associated with it, causing a crash.")
             @Config.Name("Coffin - Fix Edge Case Crash")
             public static boolean coffin_fixEdgeCrash = true;

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
@@ -17,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /**
  Mixins:
  [Bugfix] Fix Out of Bounds crash when trying to retrieve state from meta using invalid meta
+ [Bugfix] Prevent circle glyphs from being accidentally replaced by players
  */
 @Mixin(BlockCircleGlyph.class)
 public abstract class BlockCircleGlyphMixin extends Block {

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.msrandom.witchery.block.BlockCircleGlyph;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -37,6 +38,7 @@ public abstract class BlockCircleGlyphMixin extends Block {
     }
 
     /** Prevent circle glyphs from being accidentally replaced by players. */
+    @Unique
     @Override
     public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
         return !ModConfig.PatchesConfiguration.BlockTweaks.circleGlyph_preventBeingReplaced && super.isReplaceable(worldIn, pos);

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/block/BlockCircleGlyphMixin.java
@@ -5,6 +5,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.msrandom.witchery.block.BlockCircleGlyph;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -32,6 +34,12 @@ public abstract class BlockCircleGlyphMixin extends Block {
                 cir.setReturnValue(this.getDefaultState());
             }
         }
+    }
+
+    /** Prevent circle glyphs from being accidentally replaced by players. */
+    @Override
+    public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
+        return !ModConfig.PatchesConfiguration.BlockTweaks.circleGlyph_preventBeingReplaced && super.isReplaceable(worldIn, pos);
     }
 
 }


### PR DESCRIPTION
Prevent Circle Glyph from being accidentally replaced by players as it uses `Material.VINE`.