### PR TITLE
[Bugfix] Fix JEI force reloading on world load or dimension change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Companion to Witchery: Resurrected fixing bugs, crashes, patching things and a
 configurability. Witchery: Resurrected is a required dependency, and is the original 1.7.10 Witchery
 jar in the resource packs folder.
 
-## Current Features (as of v0.36.0-beta):
+## Current Features (as of v0.36.1-beta):
 ### Bugfixes:
 - **Common**
   - **[Common]** Fix crash when pulling null entity
@@ -109,6 +109,8 @@ jar in the resource packs folder.
 - **Integrations**
   - **[Botania]** Fix crash when a vampire player dies and Baubles is installed but Botania is not
   - **[Thaumcraft]** Fix Thaumcraft Integration registering aspects too early
+  - **[Just Enough Items]** Fix JEI force reloading on world load or dimension change, causing the game to hang and 
+  breaking other mods interacting with JEI (e.g. Calculator & Groovyscript)
 
 ### Tweaks
 - **Brews**

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
@@ -1521,6 +1521,7 @@ public class ModConfig {
             @Config.Comment("Fixes JEI force reloading on world load or dimension change, causing the game to hang " +
                     "and breaking other mods interacting with JEI (e.g. Calculator & Groovyscript)")
             @Config.Name("JEI Integration - Fix JEI Force Reloading")
+            @Config.RequiresMcRestart
             public static boolean fixJeiForceReloading = true;
 
             @Config.Comment("If true, enables Altar JEI Integration")

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/config/ModConfig.java
@@ -1518,6 +1518,11 @@ public class ModConfig {
 
         public static class JeiIntegration {
 
+            @Config.Comment("Fixes JEI force reloading on world load or dimension change, causing the game to hang " +
+                    "and breaking other mods interacting with JEI (e.g. Calculator & Groovyscript)")
+            @Config.Name("JEI Integration - Fix JEI Force Reloading")
+            public static boolean fixJeiForceReloading = true;
+
             @Config.Comment("If true, enables Altar JEI Integration")
             @Config.Name("JEI Integration - Altar")
             public static boolean enableJeiAltar = true;

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPlugin/CompanionMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPlugin/CompanionMixin.java
@@ -1,0 +1,44 @@
+package com.smokeythebandicoot.witcherycompanion.mixins.witchery.integration.jei.JeiWitcheryPlugin;
+
+import com.smokeythebandicoot.witcherycompanion.config.ModConfig;
+import net.minecraft.resources.ResourceManager;
+import net.msrandom.witchery.WitcheryResurrected;
+import net.msrandom.witchery.integration.jei.JeiWitcheryPlugin;
+import net.msrandom.witchery.util.WitcheryUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixins:
+ * [Bugfix] Fix JEI force reloading on world load or dimension change
+ */
+@Mixin(JeiWitcheryPlugin.Companion.class)
+public class CompanionMixin {
+
+    /**
+     * Witchery normally registers its recipes during world loading. So, even if the JEI plugin was registered
+     * normally (and not with hacky Reflection), the recipes would not be available when JEI loads. As a workaround,
+     * we forcefully register the recipes as if Witchery was in its "Compatibility Mode" where it registers client
+     * side recipes instead of waiting for the PacketUpdateRecipes to arrive during world load or dimension change.
+     */
+    @Inject(method = "load", at = @At("HEAD"), remap = false)
+    private void load(CallbackInfo ci) {
+        if(ModConfig.IntegrationConfigurations.JeiIntegration.fixJeiForceReloading) {
+            WitcheryUtils.getRECIPE_MANAGER().reload(new ResourceManager(null));
+            WitcheryResurrected.Companion.reloadRecipes();
+        }
+    }
+
+    /**
+     * Here we prevent JEI reloading since it's no longer needed.
+     */
+    @Inject(method = "reload", at = @At("HEAD"), cancellable = true, remap = false)
+    private void reload(CallbackInfo ci) {
+        if(ModConfig.IntegrationConfigurations.JeiIntegration.fixJeiForceReloading) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPlugin/CompanionMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPlugin/CompanionMixin.java
@@ -1,10 +1,7 @@
 package com.smokeythebandicoot.witcherycompanion.mixins.witchery.integration.jei.JeiWitcheryPlugin;
 
 import com.smokeythebandicoot.witcherycompanion.config.ModConfig;
-import net.minecraft.resources.ResourceManager;
-import net.msrandom.witchery.WitcheryResurrected;
 import net.msrandom.witchery.integration.jei.JeiWitcheryPlugin;
-import net.msrandom.witchery.util.WitcheryUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,20 +13,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(JeiWitcheryPlugin.Companion.class)
 public class CompanionMixin {
-
-    /**
-     * Witchery normally registers its recipes during world loading. So, even if the JEI plugin was registered
-     * normally (and not with hacky Reflection), the recipes would not be available when JEI loads. As a workaround,
-     * we forcefully register the recipes as if Witchery was in its "Compatibility Mode" where it registers client
-     * side recipes instead of waiting for the PacketUpdateRecipes to arrive during world load or dimension change.
-     */
-    @Inject(method = "load", at = @At("HEAD"), remap = false)
-    private void load(CallbackInfo ci) {
-        if(ModConfig.IntegrationConfigurations.JeiIntegration.fixJeiForceReloading) {
-            WitcheryUtils.getRECIPE_MANAGER().reload(new ResourceManager(null));
-            WitcheryResurrected.Companion.reloadRecipes();
-        }
-    }
 
     /**
      * Here we prevent JEI reloading since it's no longer needed.

--- a/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPluginMixin.java
+++ b/src/main/java/com/smokeythebandicoot/witcherycompanion/mixins/witchery/integration/jei/JeiWitcheryPluginMixin.java
@@ -1,0 +1,35 @@
+package com.smokeythebandicoot.witcherycompanion.mixins.witchery.integration.jei;
+
+import com.smokeythebandicoot.witcherycompanion.config.ModConfig;
+import mezz.jei.api.recipe.IRecipeCategoryRegistration;
+import net.minecraft.resources.ResourceManager;
+import net.msrandom.witchery.WitcheryResurrected;
+import net.msrandom.witchery.integration.jei.JeiWitcheryPlugin;
+import net.msrandom.witchery.util.WitcheryUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Mixins:
+ * [Bugfix] Fix JEI force reloading on world load or dimension change
+ */
+@Mixin(JeiWitcheryPlugin.class)
+public class JeiWitcheryPluginMixin {
+
+    /**
+     * Witchery normally registers its recipes during world loading. So, even if the JEI plugin was registered
+     * normally (and not with hacky Reflection), the recipes would not be available when JEI loads. As a workaround,
+     * we forcefully register the recipes as if Witchery was in its "Compatibility Mode" where it registers client
+     * side recipes instead of waiting for the PacketUpdateRecipes to arrive during world load or dimension change.
+     */
+    @Inject(method = "registerCategories", at = @At("HEAD"), remap = false)
+    private void injectRecipes(IRecipeCategoryRegistration registry, CallbackInfo ci) {
+        if(ModConfig.IntegrationConfigurations.JeiIntegration.fixJeiForceReloading) {
+            WitcheryUtils.getRECIPE_MANAGER().reload(new ResourceManager(null));
+            WitcheryResurrected.Companion.reloadRecipes();
+        }
+    }
+
+}

--- a/src/main/resources/mixins.witcherycompanion.json
+++ b/src/main/resources/mixins.witcherycompanion.json
@@ -184,6 +184,7 @@
   ],
   "client": [
     "witchery.block.BlockWitchesOvenMixin",
+    "witchery.integration.jei.JeiWitcheryPlugin.CompanionMixin",
     "witchery.client.ClientEvents.GuiOverlayMixin",
     "witchery.client.gui.book.GuiHerbologyBookMixin",
     "witchery.client.model.ModelFamiliarPigMixin",

--- a/src/main/resources/mixins.witcherycompanion.json
+++ b/src/main/resources/mixins.witcherycompanion.json
@@ -184,6 +184,7 @@
   ],
   "client": [
     "witchery.block.BlockWitchesOvenMixin",
+    "witchery.integration.jei.JeiWitcheryPluginMixin",
     "witchery.integration.jei.JeiWitcheryPlugin.CompanionMixin",
     "witchery.client.ClientEvents.GuiOverlayMixin",
     "witchery.client.gui.book.GuiHerbologyBookMixin",


### PR DESCRIPTION
Fixes JEI force reloading on world load or dimension change, causing the game to hang and breaking other mods interacting with JEI (e.g., Calculator & Groovyscript).

Witchery normally registers its recipes during world loading. To account for that, the JEI plugin was registered in a hacky way with Reflection by calling internal JEI methods like `startup` each time a PacketUpdateRecipes was received, causing the whole mod to reload. In my case, it was causing the game to hang for at least 45 seconds each time I loaded up a world or changed dimension.

This pull request fixes it by forcefully registering the recipes before the plugin loads, as if Witchery were in its "Compatibility Mode" where it registers client-side recipes, and then by also preventing it from reloading JEI.

It should fix https://github.com/michelegargiulo/Witchery-Companion/issues/109